### PR TITLE
chore: remove macOS from release builds until app is notarized

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-latest
-            args: '--target universal-apple-darwin'
           - platform: windows-latest
             args: ''
           - platform: ubuntu-22.04
@@ -48,8 +46,6 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
macOS Gatekeeper blocks unsigned/unnotarized apps. Removing macOS target until Apple Developer signing is set up. Windows and Linux builds remain.